### PR TITLE
Feature: Add Refunds

### DIFF
--- a/classes/class-wc-gateway-securesubmit.php
+++ b/classes/class-wc-gateway-securesubmit.php
@@ -3,7 +3,7 @@
 Plugin Name: WooCommerce SecureSubmit Gateway
 Plugin URI: https://developer.heartlandpaymentsystems.com/SecureSubmit/
 Description: Heartland Payment Systems gateway for WooCommerce.
-Version: 1.0.5
+Version: 1.1.0
 Author: SecureSubmit
 Author URI: https://developer.heartlandpaymentsystems.com/SecureSubmit/
 */

--- a/classes/class-wc-gateway-securesubmit.php
+++ b/classes/class-wc-gateway-securesubmit.php
@@ -23,7 +23,7 @@ class WC_Gateway_SecureSubmit extends WC_Payment_Gateway {
         $this->secret_key           = $this->settings['secret_key'];
         $this->public_key           = $this->settings['public_key'];
         $this->paymentaction        = $this->settings['paymentaction'];
-        $this->allow_card_saving    = (bool)$this->settings['allow_card_saving'];
+        $this->allow_card_saving    = ($this->settings['allow_card_saving'] == 'yes' ? true : false);
         $this->supports             = array(
                                         'products',
                                         'refunds',
@@ -152,7 +152,7 @@ class WC_Gateway_SecureSubmit extends WC_Payment_Gateway {
             <?php if ( $this->description ) : ?>
                 <p><?php echo $this->description; ?>
             <?php endif; ?>
-            <?php if ( $this->allow_card_saving == 'yes' ) : ?>
+            <?php if ( $this->allow_card_saving ) : ?>
                 <?php if (is_user_logged_in() && ($cards = get_user_meta( get_current_user_id(), '_secure_submit_card', false))) : ?>
                     <p class="form-row form-row-wide">
 

--- a/gateway-securesubmit.php
+++ b/gateway-securesubmit.php
@@ -3,7 +3,7 @@
 Plugin Name: WooCommerce SecureSubmit Gateway
 Plugin URI: https://developer.heartlandpaymentsystems.com/SecureSubmit/
 Description: Heartland Payment Systems gateway for WooCommerce.
-Version: 1.0.5
+Version: 1.1.0
 Author: SecureSubmit
 Author URI: https://developer.heartlandpaymentsystems.com/SecureSubmit/
 */

--- a/gateway-securesubmit.php
+++ b/gateway-securesubmit.php
@@ -4,7 +4,7 @@ Plugin Name: WooCommerce SecureSubmit Gateway
 Plugin URI: https://developer.heartlandpaymentsystems.com/SecureSubmit/
 Description: Heartland Payment Systems gateway for WooCommerce.
 Version: 1.0.5
-Author: Mark Hagan
+Author: SecureSubmit
 Author URI: https://developer.heartlandpaymentsystems.com/SecureSubmit/
 */
 add_action( 'plugins_loaded', 'woocommerce_securesubmit_init', 0 );
@@ -58,17 +58,17 @@ function woocommerce_securesubmit_init() {
 					<td><?php esc_html_e($card['exp_month']); ?> / <?php esc_html_e($card['exp_year']); ?></td>
 					<td>
 						<form action="#saved-cards" method="POST">
-	                        <?php wp_nonce_field ( 'secure_submit_del_card' ); ?>
-	                        <input type="hidden" name="delete_card" value="<?php esc_attr($i); ?>">
-	                        <input type="submit" value="Delete Card">
-	                    </form>
+                            <?php wp_nonce_field ( 'secure_submit_del_card' ); ?>
+                            <input type="hidden" name="delete_card" value="<?php esc_attr($i); ?>">
+                            <input type="submit" value="Delete Card">
+                        </form>
 					</td>
 				</tr>
 				<?php endforeach; ?>
 			</tbody>
 		</table>
 
-		<?php	
+		<?php
 	}
 
 	add_filter('woocommerce_payment_gateways', 'add_securesubmit_gateway');


### PR DESCRIPTION
Adds refund capability for WooCommerce orders in WP admin.
Changes author name in plugin headers so that the plugin shows it's by 'SecureSubmit' when looking at the plugin list.
Fixes bug with card saving. When turned off, the payment form now hides the 'Save this card' checkbox.
Bumps version to v1.1.0.